### PR TITLE
Update requirements.txt and install script

### DIFF
--- a/PyTorch/SpeechSynthesis/FastPitch/install.sh
+++ b/PyTorch/SpeechSynthesis/FastPitch/install.sh
@@ -10,7 +10,7 @@ while getopts "cu:" opt; do
       esac
     done
 : ${CONDA-"false"}  # default value
-: ${USER-`woami`}  # default value
+: ${USER-`whoami`}  # default value
 
 if [ "$CONDA" = "true" ]
 then
@@ -26,21 +26,14 @@ source /disk/scratch1/${USER}/miniconda3/bin/activate
 
 SERVERNAME=`hostname -s`
 conda create -n fastpitch_${SERVERNAME} python=3.8
+
+## Get a version of gcc > 5.0 which works to compile apex
+conda install -n fastpitch_${SERVERNAME} gcc_linux-64=8.4 gxx_linux-64=8.4
+## activating the environment now sets CC and CXX environment variables
+## to point to our gcc/g++
 source activate fastpitch_${SERVERNAME}
 
-## Get a version of gcc > 5.0. The current anaconda default (June 2021) is 9.3 which seems to work (so far!)
-conda install gcc_linux-64 gxx_linux-64
-## Make these the default C and C++ compilers (you could also set CC and CXX environment variabes)
-## But aliasing seems to work well enough
-alias gcc=x86_64-conda_cos6-linux-gnu-cc
-alias g++=x86_64-conda_cos6-linux-gnu-c++
-
 export CUDA_HOME=/opt/cuda-10.2.89_440_33
-conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-
-conda uninstall pytorch
-
-## Then we reinstall and this for some reason downgrades the gcc to 7 and then installing apex works/
 conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 
 ## Apex
@@ -51,13 +44,8 @@ pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp
 cd ../
 
 ## Python requirements
+## ignore warnings around numba installation
 pip install -r requirements.txt
-pip install tqdm tensorboard
-pip install librosa
-pip install wandb
-pip install llvmlite==0.35.0
-## Ignore warning around here
-pip install numba==0.49.1
 
 ## for logging
 ## if needed, create a free account here: https://app.wandb.ai/login?signup=true
@@ -70,7 +58,7 @@ export CUDA_VISIBLE_DEVICES=1
 ./scripts/download_fastpitch.sh
 ./scripts/download_waveglow.sh
 mkdir output
-python inference.py --cuda   --fastpitch pretrained_models/fastpitch/nvidia_fastpitch_210824.pt   --waveglow pretrained_models/waveglow/nvidia_waveglow256pyt_fp16.pt   --wn-channels 256   -i phrases/devset10.tsv   -o output/wavs_devset10
+python inference.py --cuda --fastpitch pretrained_models/fastpitch/nvidia_fastpitch_210824.pt --waveglow pretrained_models/waveglow/nvidia_waveglow256pyt_fp16.pt --wn-channels 256 -i phrases/devset10.tsv -o output/wavs_devset10
 
 
 ## Get set up with LJ

--- a/PyTorch/SpeechSynthesis/FastPitch/requirements.txt
+++ b/PyTorch/SpeechSynthesis/FastPitch/requirements.txt
@@ -1,7 +1,12 @@
-matplotlib
-numpy
+git+https://github.com/NVIDIA/dllogger#egg=dllogger
 inflect
 librosa==0.8.0
+llvmlite==0.35.0
+matplotlib
+numba==0.49.1
+numpy
 scipy
+tensorboard
 tensorboardX==2.0
-git+git://github.com/NVIDIA/dllogger.git@26a0f8f1958de2c0c460925ff6102a4d2486d6cc#egg=dllogger
+tqdm
+wandb


### PR DESCRIPTION
SLP students are running into issues installing `NVIDIA/dllogger` since upstream installation source changed. Here I've updated `requirements.txt` for that package, and also added other manually-installed dependencies to simplify the install script.

Installing a FastPitch environment on Eddie recently, I found gcc/g++ 8.4 work for the `apex` installation, so I've also manually specified those versions in the install script to save on un-/re-installing PyTorch to get the right versions in the conda environment.

Also a couple nits fixing typos and double spaces elsewhere in the install script.